### PR TITLE
Add fix for dupe with Thaumcraft Magic Mirror in the off-hand

### DIFF
--- a/src/main/java/com/focamacho/dupefixproject/mixin/thaumcraft/ContainerHandMirrorMixin.java
+++ b/src/main/java/com/focamacho/dupefixproject/mixin/thaumcraft/ContainerHandMirrorMixin.java
@@ -1,0 +1,21 @@
+package com.focamacho.dupefixproject.mixin.thaumcraft;
+
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import thaumcraft.api.items.ItemsTC;
+import thaumcraft.common.container.ContainerHandMirror;
+
+@Mixin(ContainerHandMirror.class)
+public class ContainerHandMirrorMixin {
+    @Redirect(method = "<init>", at = @At(
+            value = "INVOKE", target = "Lnet/minecraft/entity/player/InventoryPlayer;getCurrentItem()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack getCurrentItem(InventoryPlayer iinventory) {
+        ItemStack mirror = iinventory.player.getHeldItemMainhand();
+        if (!mirror.getItem().equals(ItemsTC.handMirror) || !mirror.hasTagCompound())
+            mirror = iinventory.player.getHeldItemOffhand();
+        return mirror;
+    }
+}

--- a/src/main/resources/mixins/mixins.dupefixproject.thaumcraft.json
+++ b/src/main/resources/mixins/mixins.dupefixproject.thaumcraft.json
@@ -6,6 +6,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "ContainerHandMirrorMixin",
     "ContainerRepairMixin"
   ]
 }


### PR DESCRIPTION
Video: https://www.youtube.com/watch?v=VSFodrpvRRM

Basically, if a mirror is in off-hand - the transfer of an item from hand mirror to block mirror can't happen, since Container expects the mirror to always be in the main hand. This ultimately causes a StackOverflow (InventoryHandMirror.setInventorySlotContents sees that stack wasn't sent and calls ContainerHandMirror.onCraftMatrixChanged, which sets slot contents, which updates craft matrix, which.. yeah), that sometimes results in an item both being copied into player's inventory during a shift-click and staying in the mirror's slot.

This PR ensures that the same mirror ItemStack that called openGUI is sent to ContainerHandMirror. The checks in @Redirect are enough, if you look into TC's code. This results in always correctly transfering an item, so no non-empty after-transfer ItemStacks, so no StackOverflow.