### PR TITLE
Thaumcraft Golem Dupe

### DIFF
--- a/src/main/java/com/focamacho/dupefixproject/mixin/thaumcraft/EntityThaumcraftGolemMixin.java
+++ b/src/main/java/com/focamacho/dupefixproject/mixin/thaumcraft/EntityThaumcraftGolemMixin.java
@@ -22,4 +22,8 @@ public class EntityThaumcraftGolemMixin extends EntityOwnedConstruct {
         if(getHealth() <= 0.0F) cir.setReturnValue(false);
     }
 
+    @Override
+    protected void dropEquipment(boolean wasRecentlyHit, int lootingModifier) {
+    }
+
 }


### PR DESCRIPTION
If the golem has an item in its hand, then killing it has a chance to trigger dropEquipment along with dropCarried

P.S missclicked on "r" x_x